### PR TITLE
Create ADR 0001: Record architecture decisions

### DIFF
--- a/.adr-dir
+++ b/.adr-dir
@@ -1,0 +1,1 @@
+decisions/

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@
 This repository is used to record architectural decisions made by the
 London-based digital team supporting the Offender Management in Custody
 programme.
+
+To understand why we are recording decisions and how we are doing it, please
+see ADR-0001.

--- a/decisions/0001-record-architecture-decisions.md
+++ b/decisions/0001-record-architecture-decisions.md
@@ -1,0 +1,92 @@
+# 1. Record architecture decisions
+
+Date: 2018-10-12
+
+## Status
+
+Accepted
+
+## Context
+
+During our work on Manage Offenders in Custody, we will have to make
+architectural decisions around both design and scope of the work.
+
+When making decisions, we should record them somewhere for future reference,
+to help us remember why we made them, and to help teams working in related areas
+understand why we made them.
+
+We should make our decisions public so that other teams can find them more
+easily, and because [making things open makes things better](https://www.gov.uk/guidance/government-design-principles#make-things-open-it-makes-things-better).
+
+Work done as a result of decisions we need to record is likely to be split
+across multiple repositories.
+
+## Decision
+
+We will use Architecture Decision Records, as described by Michael Nygard in
+this article: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions
+
+An architecture decision record is a short text file describing a single
+decision.
+
+We will keep ADRs in this public repository under decisions/[number]-[title].md
+
+We should use a lightweight text formatting language like Markdown.
+
+ADRs will be numbered sequentially and monotonically. Numbers will not be
+reused.
+
+If a decision is reversed, we will keep the old one around, but mark it as
+superseded. (It's still relevant to know that it was the decision, but is no
+longer the decision.)
+
+We will use a format with just a few parts, so each document is easy to digest:
+
+**Title** These documents have names that are short noun phrases. For example,
+"ADR 1: Record architectural decisions" or "ADR 9: Use Docker for deployment"
+
+**Status** A decision may be "proposed" if it's still under discussion, or
+"accepted" once it is agreed. If a later ADR changes or reverses a decision, it
+may be marked as "deprecated" or "superseded" with a reference to its
+replacement.
+
+**Context** This section describes the forces at play, including technological,
+political, social, and local to the service. These forces are probably in
+tension, and should be called out as such. The language in this section is
+value-neutral. It is simply describing facts.
+
+**Decision** This section describes our response to these forces. It is stated
+in full sentences, with active voice. "We will ..."
+
+**Consequences** This section describes the resulting context, after applying
+the decision. All consequences should be listed here, not just the "positive"
+ones. A particular decision may have positive, negative, and neutral
+consequences, but all of them affect the team and service in the future.
+
+The whole document should be one or two pages long. We will write each ADR as
+if it is a conversation with a future person joining the team. This requires
+good writing style, with full sentences organised into paragraphs. Bullets are
+acceptable only for visual style, not as an excuse for writing sentence
+fragments.
+
+[adr-tools](https://github.com/npryce/adr-tools) can help us work with our ADRs
+consistently.
+
+We will link to these ADRs from other documentation where relevant.
+
+## Consequences
+
+One ADR describes one significant decision for the service. It should be
+something that has an effect on how the rest of the service will run.
+
+Developers and service stakeholders (and anyone else who's interested) can see
+the ADRs, even as the team composition changes over time.
+
+The motivation behind previous decisions is visible for everyone, present and
+future. Nobody is left scratching their heads to understand, "What were they
+thinking?" and the time to change old decisions will be clear from changes in
+the service's context.
+
+Having a central place to record decisions which affect all of our work will
+make the sequence of decisions clear, and make it easier for us to refer back to
+decisions later on.


### PR DESCRIPTION
The content of this ADR is based heavily on the LAA Hosting equivalent ADR
[1], which in turn is based on Michael Nygard's post about ADRs [2].

I've marked this ADR as `Accepted` because we've already agreed to use ADRs. The
details of how we use them are still open for discussion, which can happen on
the pull request.

Refer to this ADR from the README.

Include adr-tools config to specify the directory to keep ADRs in, matching
the decision recorded in 0001.

[1]: https://github.com/ministryofjustice/laa-hosting-architectural-decisions/blob/827b8832c32577119f8ac49e4520fc689a3bded1/doc/adr/0001-record-architecture-decisions.md
[2]: http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions