### PR TITLE
Table of contents 🤔✅❌♻️

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,22 @@ programme.
 
 To understand why we are recording decisions and how we are doing it, please
 see [ADR-0001](decisions/0001-record-architecture-decisions.md).
+
+## Table of contents
+
+* [1. Record architecture decisions](decisions/0001-record-architecture-decisions.md)
+* [2. Use Cloud Platform for hosting](decisions/0002-use-cloud-platform-for-hosting.md)
+* [3. Use progressive enhancement](decisions/0003-use-progressive-enhancement.md)
+* [4. Separate API and user-facing applications](decisions/0004-separate-api-and-user-facing-applications.md)
+* [5. Allocation API owns allocation data](decisions/0005-allocation-api-owns-allocation-data.md)
+* [6. Use the Custody API to access NOMIS data](decisions/0006-use-the-custody-api-to-access-nomis-data.md)
+* [7. Use Ruby for new applications for Manage Offenders in Custody](decisions/0007-use-ruby-for-new-applications-for-manage-offenders-in-custody.md)
+* [8. Use Rails](decisions/0008-use-rails.md)
+* [9. Use CircleCI for CI and deployment](decisions/0009-use-circleci-for-ci-and-deployment.md)
+
+### Statuses:
+
+* Proposed: 🤔
+* Accepted: ✅
+* Rejected: ❌
+* Superseded: ♻️

--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ see [ADR-0001](decisions/0001-record-architecture-decisions.md).
 
 ## Table of contents
 
-* [1. Record architecture decisions](decisions/0001-record-architecture-decisions.md)
-* [2. Use Cloud Platform for hosting](decisions/0002-use-cloud-platform-for-hosting.md)
-* [3. Use progressive enhancement](decisions/0003-use-progressive-enhancement.md)
-* [4. Separate API and user-facing applications](decisions/0004-separate-api-and-user-facing-applications.md)
-* [5. Allocation API owns allocation data](decisions/0005-allocation-api-owns-allocation-data.md)
-* [6. Use the Custody API to access NOMIS data](decisions/0006-use-the-custody-api-to-access-nomis-data.md)
-* [7. Use Ruby for new applications for Manage Offenders in Custody](decisions/0007-use-ruby-for-new-applications-for-manage-offenders-in-custody.md)
-* [8. Use Rails](decisions/0008-use-rails.md)
-* [9. Use CircleCI for CI and deployment](decisions/0009-use-circleci-for-ci-and-deployment.md)
+* ✅ [1. Record architecture decisions](decisions/0001-record-architecture-decisions.md)
+* ✅ [2. Use Cloud Platform for hosting](decisions/0002-use-cloud-platform-for-hosting.md)
+* ✅ [3. Use progressive enhancement](decisions/0003-use-progressive-enhancement.md)
+* ✅ [4. Separate API and user-facing applications](decisions/0004-separate-api-and-user-facing-applications.md)
+* ✅ [5. Allocation API owns allocation data](decisions/0005-allocation-api-owns-allocation-data.md)
+* ✅ [6. Use the Custody API to access NOMIS data](decisions/0006-use-the-custody-api-to-access-nomis-data.md)
+* ✅ [7. Use Ruby for new applications for Manage Offenders in Custody](decisions/0007-use-ruby-for-new-applications-for-manage-offenders-in-custody.md)
+* ✅ [8. Use Rails](decisions/0008-use-rails.md)
+* ✅ [9. Use CircleCI for CI and deployment](decisions/0009-use-circleci-for-ci-and-deployment.md)
 
 ### Statuses:
 


### PR DESCRIPTION
This was initially generated with:

    adr generate toc -p decisions/

adr-tools writes this to stdout and doesn't support inserting it into a file,
so I've copied it across manually for now. We could script the generation of
the README including this output in future.

[adr-log](https://github.com/adr/adr-log) also exists and can insert a table of contents into an existing file,
but it's an npm package and I'd rather not introduce that as a dependency in
the context of this repo.

The emoji make it easier to see the statuses of ADRs in the table of contents,
but harder to automate creating it.