### PR TITLE
Document our intention to use Elite2

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ see [ADR-0001](decisions/0001-record-architecture-decisions.md).
 * ✅ [13. Use NOMIS SSO for user authentication](decisions/0013-use-nomis-sso-for-user-authentication.md)
 * ✅ [14. Access the Delius API via NDH](decisions/0014-access-the-delius-api-via-ndh.md)
 * ✅ [15. Manage short-lived access tokens in tests](decisions/0015-manage-short-lived-access-tokens-in-test.md)
+* ✅ [16. Use the Elite2 API](decisions/0016-use-the-elite2-api.md)
 
 ### Statuses:
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ see [ADR-0001](decisions/0001-record-architecture-decisions.md).
 * ✅ [3. Use progressive enhancement](decisions/0003-use-progressive-enhancement.md)
 * ♻️ [4. Separate API and user-facing applications](decisions/0004-separate-api-and-user-facing-applications.md)
 * ✅ [5. Allocation API owns allocation data](decisions/0005-allocation-api-owns-allocation-data.md)
-* ✅ [6. Use the Custody API to access NOMIS data](decisions/0006-use-the-custody-api-to-access-nomis-data.md)
+* ♻️ [6. Use the Custody API to access NOMIS data](decisions/0006-use-the-custody-api-to-access-nomis-data.md)
 * ✅ [7. Use Ruby for new applications for Manage Offenders in Custody](decisions/0007-use-ruby-for-new-applications-for-manage-offenders-in-custody.md)
 * ✅ [8. Use Rails](decisions/0008-use-rails.md)
 * ✅ [9. Use CircleCI for CI and deployment](decisions/0009-use-circleci-for-ci-and-deployment.md)

--- a/decisions/0006-use-the-custody-api-to-access-nomis-data.md
+++ b/decisions/0006-use-the-custody-api-to-access-nomis-data.md
@@ -6,6 +6,8 @@ Date: 2018-10-19
 
 Accepted
 
+Amended by [16. Use the Elite2 API to access NOMIS data](0016-use-elite2-api.md)
+
 ## Context
 
 Our main source of data on prisoners and prison staff which we need for

--- a/decisions/0016-use-elite2-api.md
+++ b/decisions/0016-use-elite2-api.md
@@ -1,0 +1,45 @@
+# 6. Use the Elite2 API to access NOMIS data
+
+Date: 2019-01-18
+
+## Status
+
+Accepted
+
+## Context
+
+Our main source of data on prisoners and prison staff is NOMIS. The
+allocation tool currently uses the Custody API, as decided in [ADR 0006](https://github.com/ministryofjustice/offender-management-architecture-decisions/blob/master/decisions/0006-use-the-custody-api-to-access-nomis-data.md), to retrieve
+data on both offenders and staff.
+
+Initial use of the Custody API has raised some issues. Problems exist
+with the locality of data, N+1 API requests, and data that is unavailable
+through the currently published endpoints. These issues are intrinsic to
+the current design of the Custody API, and it is unlikely that they will
+be resolved or mitigated in the short to medium term.
+
+The Elite2 API, a fork of the Custody API, is under more active development
+and provides endpoints more focused on the need of clients. Most of the
+endpoints available work on the caseload of the connecting client token,
+but also support the provision of more specific parameters to handle
+alternate needs.  Although we will not be authenticating with the token
+of the eventual end user, enough flexibility exists for us to obtain the
+data we require from Elite2.
+
+
+## Decision
+
+We will use the Elite2 API for access to the data we require from NOMIS.
+
+We will work with the team in Sheffield on development of the Elite2 API to
+add support for accessing the data we need, in the structure that we need it.
+
+## Consequences
+
+We will have to rework the existing code to use the new API.
+
+We will need to spend several days of pairing with people from Sheffield
+to be able to contribute effectively.
+
+We will need ongoing support from the team in Sheffield to review pull requests
+and deploy API changes for us.

--- a/decisions/0016-use-elite2-api.md
+++ b/decisions/0016-use-elite2-api.md
@@ -1,4 +1,4 @@
-# 6. Use the Elite2 API to access NOMIS data
+# 16. Use the Elite2 API to access NOMIS data
 
 Date: 2019-01-18
 
@@ -12,19 +12,36 @@ Our main source of data on prisoners and prison staff is NOMIS. The
 allocation tool currently uses the Custody API, as decided in [ADR 0006](https://github.com/ministryofjustice/offender-management-architecture-decisions/blob/master/decisions/0006-use-the-custody-api-to-access-nomis-data.md), to retrieve
 data on both offenders and staff.
 
-Initial use of the Custody API has raised some issues. Problems exist
+There are still four APIs into NOMIS providing general data access, with varying
+approaches to presenting the data and authentication. We still do not want to add
+to this duplication.
+
+Although it has been agreed by the HMPPS technical community that we would
+like to move all clients to use the Custody API in preference to the other APIs,
+initial use of the Custody API has raised some issues. Problems exist
 with the locality of data, N+1 API requests, and data that is unavailable
 through the currently published endpoints. These issues are intrinsic to
 the current design of the Custody API, and it is unlikely that they will
-be resolved or mitigated in the short to medium term.
+be resolved or mitigated in the short to medium term. The scale of the work
+required makes it unrealistic that we would be able to deliver this in a
+realistic timescale.
 
-The Elite2 API, a fork of the Custody API, is under more active development
-and provides endpoints more focused on the need of clients. Most of the
-endpoints available work on the caseload of the connecting client token,
-but also support the provision of more specific parameters to handle
-alternate needs.  Although we will not be authenticating with the token
-of the eventual end user, enough flexibility exists for us to obtain the
-data we require from Elite2.
+The Elite2 API, is under more active development, is entirely owned by the
+Sheffield team and provides endpoints more focused on the need of clients.
+Most of the endpoints available work on the caseload of the connecting
+client token, but also support the provision of more specific parameters
+to handle alternate needs. Although we will not be authenticating with
+the token of the eventual end user, enough flexibility exists for us to
+obtain the data we require from Elite2.
+
+Elite2 provides functionality closer to what we currently require
+and it's design encompasses the need for extra API endpoints for specific
+services. Moving to Elite2 is a pragmatic, and tactical approach to
+resolving the issues around the Cutody API to allow us to deliver the
+allocation component of MOiC. This decision doesn't invalidate the
+overall agreed strategy of moving HMPPS services to the Custody API
+over time, but it highlights that more coordinated work is needed to
+achieve that than we are able to take on ourselves.
 
 
 ## Decision

--- a/decisions/0016-use-elite2-api.md
+++ b/decisions/0016-use-elite2-api.md
@@ -35,9 +35,9 @@ the token of the eventual end user, enough flexibility exists for us to
 obtain the data we require from Elite2.
 
 Elite2 provides functionality closer to what we currently require
-and it's design encompasses the need for extra API endpoints for specific
+and its design encompasses the need for extra API endpoints for specific
 services. Moving to Elite2 is a pragmatic, and tactical approach to
-resolving the issues around the Cutody API to allow us to deliver the
+resolving the issues around the Custody API to allow us to deliver the
 allocation component of MOiC. This decision doesn't invalidate the
 overall agreed strategy of moving HMPPS services to the Custody API
 over time, but it highlights that more coordinated work is needed to


### PR DESCRIPTION
This PR documents our intention to use Elite2 for access to NOMIS data
rather than the current use of the Custody API.