### PR TITLE
Use blue-green deployments to manage database migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ see [ADR-0001](decisions/0001-record-architecture-decisions.md).
 * ✅ [14. Access the Delius API via NDH](decisions/0014-access-the-delius-api-via-ndh.md)
 * ✅ [15. Manage short-lived access tokens in tests](decisions/0015-manage-short-lived-access-tokens-in-test.md)
 * ✅ [16. Use the Elite2 API](decisions/0016-use-the-elite2-api.md)
-* ✅ [17. Database migrations](decisions/0017-database-migrations.md)
+* ✅ [17. Use blue-green deployments to manage database migrations](decisions/0017-Use blue-green deployments to manage database migrations.md)
 
 ### Statuses:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ see [ADR-0001](decisions/0001-record-architecture-decisions.md).
 * ✅ [14. Access the Delius API via NDH](decisions/0014-access-the-delius-api-via-ndh.md)
 * ✅ [15. Manage short-lived access tokens in tests](decisions/0015-manage-short-lived-access-tokens-in-test.md)
 * ✅ [16. Use the Elite2 API](decisions/0016-use-the-elite2-api.md)
+* ✅ [17. Database migrations](decisions/0017-database-migrations.md)
 
 ### Statuses:
 

--- a/decisions/0017-database-migrations.md
+++ b/decisions/0017-database-migrations.md
@@ -1,4 +1,4 @@
-# 17. Database migrations
+# 17. Use blue-green deployments to manage database migrations
 
 Date: 2019-01-24
 

--- a/decisions/0017-database-migrations.md
+++ b/decisions/0017-database-migrations.md
@@ -1,0 +1,29 @@
+# 17. Database migrations
+
+Date: 2019-01-24
+
+## Status
+
+Accepted
+
+## Context
+
+We have reached a point where we are going to start reading and writing data to our Allocation API application database and will need to manage database migrations when adding tables, columns and so forth.  This ADR decision outlines the agreed upon approach that the team will take for managing these migrations.
+
+## Decision
+
+We will use blue-green deployments split into the following steps (using adding column as an example):
+
+* Add a database migration that inserts the new column
+* Update the application so that all new data gets written to new column
+* Run a task to copy all the data from the old column to the new column
+* Update the application so that it reads from the new column
+* Add a database migration that removes the old column
+
+We will also ensure that any migrations include 'up' and 'down' methods, rather than just 'change' to avoid any situations where Rails doesn't know how to handle the inverse of the up or down.
+
+## Consequences
+
+This will reduce downtime, and reduce the risk of losing data as we can more granularly control individual tasks rather than it happening in one big bang type event that you can't recover from.
+
+Another ADR will be required once we have researched, discussed and decided on how we will manage situations involving rollbacks.


### PR DESCRIPTION
This PR documents our intention on how to manage database migrations.