### PR TITLE
Unify API and Presentation layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ see [ADR-0001](decisions/0001-record-architecture-decisions.md).
 * ✅ [7. Use Ruby for new applications for Manage Offenders in Custody](decisions/0007-use-ruby-for-new-applications-for-manage-offenders-in-custody.md)
 * ✅ [8. Use Rails](decisions/0008-use-rails.md)
 * ✅ [9. Use CircleCI for CI and deployment](decisions/0009-use-circleci-for-ci-and-deployment.md)
-* ✅ [10. Allocation API has less responsibility](decisions/0010-allocation-api-has-less-responsibility.md)
+* ♻️ [10. Allocation API has less responsibility](decisions/0010-allocation-api-has-less-responsibility.md)
 * ✅ [11. Use NOMIS OAuth2 server for allocation API authentication](decisions/0011-use-nomis-oauth-server2-for-allocation-api-authentication.md)
 * ✅ [12. Start out with one environment which uses T3 NOMIS](decisions/0012-start-out-with-one-environment-which-uses-t3-nomis.md)
 * ✅ [13. Use NOMIS SSO for user authentication](decisions/0013-use-nomis-sso-for-user-authentication.md)
 * ✅ [14. Access the Delius API via NDH](decisions/0014-access-the-delius-api-via-ndh.md)
 * ✅ [15. Manage short-lived access tokens in tests](decisions/0015-manage-short-lived-access-tokens-in-test.md)
 * ✅ [16. Use the Elite2 API](decisions/0016-use-the-elite2-api.md)
-* ✅ [17. Use blue-green deployments to manage database migrations](decisions/0017-Use blue-green deployments to manage database migrations.md)
+* ✅ [17. Use blue-green deployments to manage database migrations](decisions/0017-database-migrations.md)
 * 🤔 [18. Testing TLS mutual auth for Delius API access](decisions/0018-testing-tls-mutual-auth-for-delius-api-access.md)
 * ✅ [19. Manage runtime secrets with git-crypt](decisions/0019-manage-runtime-secrets-with-git-crypt.md)
+* ✅ [20. Unify API and Presentation layer](decisions/0018-unify-api-and-presentation-layer.md)
 
 
 ### Statuses:

--- a/decisions/0004-separate-api-and-user-facing-applications.md
+++ b/decisions/0004-separate-api-and-user-facing-applications.md
@@ -8,6 +8,8 @@ Accepted
 
 Amended by [10. Allocation API has less responsibility](0010-allocation-api-has-less-responsibility.md)
 
+Amended by [18. Unify API and Presentation layer](0018-unify-api-and-presentation-layer.md)
+
 ## Context
 
 We are moving into beta on allocations, which is the first area of our work on

--- a/decisions/0010-allocation-api-has-less-responsibility.md
+++ b/decisions/0010-allocation-api-has-less-responsibility.md
@@ -8,6 +8,8 @@ Accepted
 
 Amends [4. Separate API and user-facing applications](0004-separate-api-and-user-facing-applications.md)
 
+Amended by [18. Unify API and Presentation layer](0018-unify-api-and-presentation-layer.md)
+
 ## Context
 
 When we decided to start off with separate API and user-facing applications

--- a/decisions/0020-unify-api-and-presentation-layer.md
+++ b/decisions/0020-unify-api-and-presentation-layer.md
@@ -1,0 +1,64 @@
+# 16. Unify API and Presentation layers
+
+Date: 2019-02-06
+
+## Status
+
+Accepted
+
+Amends [Separate API and user facing applications](https://github.com/ministryofjustice/offender-management-architecture-decisions/blob/master/decisions/0004-separate-api-and-user-facing-applications)
+
+Amends [Allocation API has less responsibility](https://github.com/ministryofjustice/offender-management-architecture-decisions/blob/master/decisions/0010-allocation-api-has-less-responsibility)
+
+## Context
+
+Previously, it was decided in [ADR 0004](https://github.com/ministryofjustice/offender-management-architecture-decisions/blob/master/decisions/0004-separate-api-and-user-facing-applications) that we would separate data and presentation concerns.  This however was reversed by [ADR 0010](https://github.com/ministryofjustice/offender-management-architecture-decisions/blob/master/decisions/0010-allocation-api-has-less-responsibility) which meant there was an overlap of data concerns with some data access from the presentation layer, and some via the Allocation API.
+
+It was envisioned that starting off with more than one application would mean
+that we would be able to structure the responsibilities early in the process and
+reduce later efforts, but in practice this has not happened. With more exposure
+to some of the APIs we are dependent on which service should access them has
+become less clear over time.  For instance, it was discovered that it was better
+for the Allocation API to retrieve staff data from Elite2, rather than the
+presentation layer.
+
+There was concern that later migration from a monolith to separate services would
+be technical debt that we would be unable to pay off in future, due to other
+competing pressures. The cost of managing two different services, sharing contexts
+and overlapping boundaries has however increased the development complexity and
+cognitive load.
+
+There was a requirement that other services are likely to require access to the
+allocation information that we have stored. This made sense when there was a
+clean separation of concerns (with all data access via the Allocation API) but
+currently provides little benefit. Whether the API is a separate service or
+a modular component of a monolith is currently a deployment strategy as
+architecturally it provides few benefits over a modular application. It is
+entirely possible to provide an API via a modular monolith.
+
+As we have progressed with development, we have encountered issues with
+our approach of enriching API sourced data with locally acquired data. Processes
+where we retrieve data, enrich it with data from external APIs and then enrich it
+with data from local APIs result in the movement of lots of data which has
+performance costs.  Direct access to the database for 'local' data would
+remove issues with both performance and moving data across boundaries containing
+isolated (but related) logic.
+
+## Decision
+
+We will integrate the existing Allocation API into the Allocation Manager, and make
+the public api available at /api.
+
+We will work in a single unified codebase in a well-designed modules to
+reduce some future effort in separating concerns.
+
+## Consequences
+
+We expect this to reduce cognitive load, and complexity for developer whilst improving
+the performance with respect to data processing.
+
+We may require some time in decommissioning (but not yet destroying) existing
+infrastructure for the Allocation API service.
+
+In the future, should the operational need arise, we may need to spend some time
+separating out the minimal public API into a separate service.


### PR DESCRIPTION
This PR discusses the decision reached with the team around simplifying
development, deployment and management of the allocation tool.  This is
essentially moving to a monolith as a starting point, until we have an
operational need to break the service apart, at which point we can
define the boundaries based on experience of running the system.